### PR TITLE
Bib0x/show used envvars

### DIFF
--- a/cmd/actions
+++ b/cmd/actions
@@ -62,3 +62,14 @@ function __ovm_cmd_do_ls {
     unset IFS
     echo ""
 }
+
+function __ovm_cmd_do_show_envvars {
+    IFS=:
+    for p in $OVM_MODULES_PATH;
+    do
+        if [ -d "$p" ]; then
+            grep -hR 'export OVM_' "$p"/
+        fi
+    done
+    unset IFS
+}

--- a/ovm
+++ b/ovm
@@ -34,6 +34,7 @@ function __ovm_usage {
     echo "Commands"
     echo "--------"
     echo "ovm <command>"
+    echo "    env       show environment variables defined/used in modules"
     echo "    info      show module information in README.md (if available)"
     echo "    load      load all functions in a module"
     echo "    ls        list available modules and functions"
@@ -50,6 +51,9 @@ function ovm {
             case $1 in
                 ls)
                     __ovm_cmd_do_ls
+                    ;;
+                env)
+                    __ovm_cmd_do_show_envvars
                     ;;
                  *)
                     echo "option $1 not defined."

--- a/ovm-completion.bash
+++ b/ovm-completion.bash
@@ -12,7 +12,7 @@ function __ovm_completions() {
 
     case $COMP_CWORD in
         1)
-            opts="info load ls"
+            opts="env info load ls"
             COMPREPLY=( $( compgen -W "${opts}" -- "$cur" ) )
             ;;
         2)


### PR DESCRIPTION
This PR adds the possibility to search for environment variables needed or used by modules.
It helps to see what configuration to override to be able to load a module.

```
$ ovm env
export FSALIAS_VAR_XXX=YYYY
export FSALIAS_VAR_YYY=ZZZZ
```
Also, the output can enables to create a `.ovmrc` file containing all environment variables needed. 
