### PR TITLE
delete harcoded path for cat binary and add bat support

### DIFF
--- a/lib/dumper
+++ b/lib/dumper
@@ -31,8 +31,16 @@ function __ovm_markdown_dumper {
         fi
     fi
 
+    # Bat
+    command -v bat >/dev/null 2>&1
+    if [ $? -eq 0 ];
+    then
+        bat "$path"
+        return
+    fi
+    
     # Default
-    /bin/cat "$path"
+    cat "$path"
 }
 
 function __ovm_highlight {


### PR DESCRIPTION
This MR aims to fix this compatibility issue #4 

It also add `bat` binary support for the command `ovm info <module>`.