### PR TITLE
git-crypt: new module

### DIFF
--- a/modules/git-crypt/README.md
+++ b/modules/git-crypt/README.md
@@ -1,0 +1,14 @@
+# [git-crypt]
+
+This module contains wrapper from git-crypt utility.
+
+## git-crypt-pubkey-info
+
+Search for email address associated to each public key.
+
+```
+$ git-crypt-pubkey-info <directory>
+
+$ git-crypt-pubkey-info .git-crypt/keys/default/0 
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.gpg: "bib0x <bib0x@bib0x.lab.local>"
+```

--- a/modules/git-crypt/functions/pubkey-info
+++ b/modules/git-crypt/functions/pubkey-info
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source "$OVM_PATH/lib/validator"
+
+# ---------------------------------------
+# Requirements
+# ---------------------------------------
+local packages=("gpg" "grep" "sed")
+
+__ovm_validator_packages "${packages[@]}" || return
+
+# ---------------------------------------
+# Code
+# ---------------------------------------
+function git-crypt-pubkey-info {
+
+  [ $# -le 1 ] || { echo "usage: ${FUNCNAME[0]} <gpg-keys-directory>"; return 1; }
+
+  directory=${1:-.git-crypt/keys/default/0}
+  for key in $directory/*.gpg; do
+    keyfile=$(basename "$key")
+    echo -n "$keyfile: "
+    gpg --list-packets "$key" 2>&1 | grep '@' | sed -E 's/^\s+//g'
+  done
+
+}

--- a/modules/git-crypt/loader
+++ b/modules/git-crypt/loader
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source "$OVM_PATH/lib/loader"
+
+root=$(dirname "${BASH_SOURCE[0]}")
+__ovm_dynamic_loader "$root/functions"


### PR DESCRIPTION
add function git-crypt-pubkey-info to get GPG public keys identity from a git-crypt repository